### PR TITLE
fix: wrong workflow in libs release CI

### DIFF
--- a/.github/workflows/lib-release.yaml
+++ b/.github/workflows/lib-release.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   quality:
-    uses: ./.github/workflows/pull-request.yaml
+    uses: ./.github/workflows/lib-pull-request.yaml
   release:
     name: Build and Publish to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Wrong CI workflow reference was used in the lib release CI.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
