### PR TITLE
feat: status manager

### DIFF
--- a/auth/src/litmus_auth.py
+++ b/auth/src/litmus_auth.py
@@ -31,6 +31,7 @@ class LitmusAuth:
         self._container = container
         self._db_config = db_config
         self._backend_grpc_endpoint = backend_grpc_endpoint
+        self._container.get_check()
 
     def reconcile(self):
         """Unconditional control logic."""

--- a/libs/src/litmus_libs/status_manager.py
+++ b/libs/src/litmus_libs/status_manager.py
@@ -1,0 +1,68 @@
+"""Litmus charms status collection utilities."""
+from typing import Any, Iterable, Sequence
+
+import ops
+from ops.pebble import CheckStatus
+
+
+class StatusManager:
+    """Set the appropriate status on a collect status event."""
+    _relations_missing_msg_template = "Missing [{}] integration(s)."
+    _configs_missing_msg_template = "Required configurations [{}] not ready yet."
+    _checks_failing_msg_template = "Pebble checks [{}] are 'DOWN'."
+
+    def __init__(self,
+                 charm: ops.CharmBase,
+                 wait_for_config: dict[str, Any|None] = None,
+                 block_if_relations_missing: Iterable[str] = None,
+                 block_if_pebble_checks_failing: dict[str, Sequence[str]] = None,
+                 ):
+        self._wait_for_config = wait_for_config or {}
+        self._block_if_relations_missing = block_if_relations_missing or ()
+        self._block_if_pebble_checks_failing = block_if_pebble_checks_failing or {}
+        self._charm = charm
+
+    def collect_status(self, e:ops.CollectStatusEvent):
+        """Check the status."""
+        for status in filter(None, (
+            self._blocked_if_relations_missing(),
+            self._waiting_if_configs_missing(),
+            self._blocked_if_pebble_checks_failing()
+        )):
+            e.add_status(status)
+
+    def _blocked_if_relations_missing(self)->ops.StatusBase|None:
+        """Set blocked status if any required relation is missing."""
+        missing_relations = [
+            rel
+            for rel in self._block_if_relations_missing
+            if not self._charm.model.get_relation(rel)
+        ]
+        if missing_relations:
+            return ops.BlockedStatus(self._relations_missing_msg_template.format(", ".join(missing_relations)))
+        return None
+
+    def _waiting_if_configs_missing(self)->ops.StatusBase|None:
+        """Set waiting status if any required config is missing."""
+        missing_configs = [
+            config_name
+            for config_name, source in self._wait_for_config.items()
+            if source is None
+        ]
+        if missing_configs:
+            return ops.WaitingStatus(self._configs_missing_msg_template.format(', '.join(missing_configs)))
+        return None
+
+    def _blocked_if_pebble_checks_failing(self)->ops.StatusBase|None:
+        """Set blocked status if any pebble check is not reporting UP."""
+        failing_checks = []
+        for container_name, checks in self._block_if_pebble_checks_failing.items():
+            container = self._charm.unit.get_container(container_name)
+            checks_status = container.get_checks(*checks)
+            for check_name, check_status in checks_status.items():
+                if check_status.status is CheckStatus.DOWN:
+                    failing_checks.append(check_name)
+
+        if failing_checks:
+            return ops.BlockedStatus(self._checks_failing_msg_template.format(", ".join(failing_checks)))
+        return None

--- a/libs/tests/unit/test_status_manager.py
+++ b/libs/tests/unit/test_status_manager.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock
+
+import ops
+import pytest
+import scenario
+
+from litmus_libs.status_manager import StatusManager
+
+
+@pytest.mark.parametrize(
+    "spec, expected_missing",
+    (
+        ({"foo": None, "bar": None, "baz": None}, "foo, bar, baz"),
+        ({"foo": None, "bar": None, "baz": 42}, "foo, bar"),
+        ({"foo": True, "bar": None, "baz": 42}, "bar"),
+        ({"foo": True, "bar": [42], "baz": 42}, ""),
+    )
+
+)
+def test_manager_sets_waiting_on_config_missing(spec, expected_missing):
+    sm = StatusManager(MagicMock(), wait_for_config=spec)
+    event = MagicMock()
+    sm.collect_status(event)
+    if not expected_missing:
+        assert not event.add_status.called
+    else:
+        assert event.add_status.called
+        call_args = event.add_status.call_args
+        expected_msg = sm._configs_missing_msg_template.format(expected_missing)
+        assert call_args.args[0].message == expected_msg
+
+
+@pytest.mark.parametrize(
+    "required, present, expected_missing",
+    (
+        (["foo", "bar"], ["foo"], "bar"),
+        (["foo", "bar", "baz"], ["foo"], "bar, baz"),
+        (["foo", "bar", "baz"], ["foo", "bar", "baz"], ""),
+    )
+
+)
+def test_manager_sets_waiting_on_relations_missing(required, present, expected_missing):
+    charm = MagicMock()
+    charm.model.get_relation = lambda name: name in present
+    sm = StatusManager(charm, block_if_relations_missing=required)
+    event = MagicMock()
+    sm.collect_status(event)
+    if not expected_missing:
+        assert not event.add_status.called
+    else:
+        assert event.add_status.called
+        call_args = event.add_status.call_args
+        expected_msg = sm._relations_missing_msg_template.format(expected_missing)
+        assert call_args.args[0].message == expected_msg
+
+
+
+@pytest.mark.parametrize(
+    "required, passing, expected_failing",
+    (
+        (["foo", "bar"], ["foo"], "bar"),
+        (["foo", "bar", "baz"], ["foo"], "bar, baz"),
+        (["foo", "bar", "baz"], ["foo", "bar", "baz"], ""),
+    )
+
+)
+def test_manager_sets_blocked_on_checks_failing(required, passing, expected_failing):
+    charm = MagicMock()
+    check_status = {name: ops.pebble.CheckInfo(name,
+                                               level=ops.pebble.CheckLevel.READY,
+                                               status=(ops.pebble.CheckStatus.UP if name in passing else ops.pebble.CheckStatus.DOWN))
+                    for name in required}
+    charm.unit.get_container.return_value.get_checks = lambda *_: check_status
+    sm = StatusManager(charm, block_if_pebble_checks_failing={"container": required})
+    event = MagicMock()
+    sm.collect_status(event)
+    if not expected_failing:
+        assert not event.add_status.called
+    else:
+        assert event.add_status.called
+        call_args = event.add_status.call_args
+        expected_msg = sm._checks_failing_msg_template.format(expected_failing)
+        assert call_args.args[0].message == expected_msg
+
+
+
+@pytest.fixture
+def ctx():
+    class MyCharm(ops.CharmBase):
+        META = {"name": "bartlomiej",
+                "containers": {"container1": {}},
+                "requires": {"rel1": {"interface": "bar"}},
+                }
+        CONFIG={"options":{"cfg1": {"type": "boolean"}}}
+
+        def __init__(self, f):
+            super().__init__(f)
+            self.framework.observe(self.on.collect_unit_status, self._collect_status)
+
+        def _collect_status(self, e):
+            StatusManager(self,
+                          wait_for_config={"cfg1": self.config.get('cfg1'), "bar": 1, "baz": 0},
+                          block_if_pebble_checks_failing={"container1": ("check1", )},
+                          block_if_relations_missing=['rel1']
+                          ).collect_status(e)
+            e.add_status(ops.ActiveStatus("happy status!"))
+
+    ctx = scenario.Context(MyCharm, meta=MyCharm.META, config=MyCharm.CONFIG)
+    return ctx
+
+
+@pytest.mark.parametrize("fail", ("checks", "relation", "config", None))
+def test_status_mgr_charm_api_checks(ctx, fail):
+    check_status = ops.pebble.CheckStatus.DOWN if fail == "checks" else ops.pebble.CheckStatus.UP
+
+    state_in = scenario.State(
+        config={} if fail =="config" else {"cfg1": True},
+        relations= {} if fail == "relation" else {scenario.Relation("rel1")},
+        containers={
+            scenario.Container("container1",
+                               _base_plan={"checks": {"check1":{"threshold": 3,
+                                                                "startup": "enabled",
+                                                                "level": None}}},
+                               check_infos={scenario.CheckInfo("check1", status=check_status)})
+        }
+    )
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+
+    match fail:
+        case "checks":
+            assert state_out.unit_status.message == StatusManager._checks_failing_msg_template.format("check1")
+        case "relation":
+            assert state_out.unit_status.message == StatusManager._relations_missing_msg_template.format("rel1")
+        case "config":
+            assert state_out.unit_status.message == StatusManager._configs_missing_msg_template.format("cfg1")
+        case None:
+            assert state_out.unit_status.message == "happy status!"
+


### PR DESCRIPTION
Adds a status manager class to abstract some of the shared status management code between the charms.
Before:
```
    def _on_collect_unit_status(self, e: CollectStatusEvent):
        missing_relations = [
            rel
            for rel in (DATABASE_ENDPOINT, LITMUS_AUTH_ENDPOINT)
            if not self.model.get_relation(rel)
        ]
        missing_configs = [
            config_name
            for config_name, source in (
                ("database config", self.database_config),
                ("backend gRPC endpoint", self.backend_grpc_endpoint),
            )
            if not source
        ]
        if missing_relations:
            e.add_status(
                BlockedStatus(
                    f"Missing [{', '.join(missing_relations)}] integration(s)."
                )
            )
        if missing_configs:
            e.add_status(
                WaitingStatus(f"[{', '.join(missing_configs)}] not provided yet.")
            )

        # TODO: add pebble check to verify auth server is up
        #  https://github.com/canonical/litmus-operators/issues/36
        e.add_status(ActiveStatus(""))
```

after:
```
    def _on_collect_unit_status(self, e: CollectStatusEvent):
            StatusManager(self,
                          wait_for_config= {"database config": self.database_config,
                                                            "backend gRPC endpoint": self.backend_grpc_endpoint},
                          block_if_pebble_checks_failing={"mycontainer": ("mycheck", )},
                          block_if_relations_missing=['rel1', 'rel2']
                          ).collect_status(e)
            e.add_status(ops.ActiveStatus("happy status!"))
```