### PR TITLE
feat: Use ingress over traefik-route

### DIFF
--- a/chaoscenter/charmcraft.yaml
+++ b/chaoscenter/charmcraft.yaml
@@ -52,6 +52,9 @@ requires:
     limit: 1
     description: |
       Receive TLS certificates.
+  ingress:
+    interface: traefik_route
+    limit: 1
 
 
 links:

--- a/chaoscenter/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/chaoscenter/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for traefik_route.
+
+This library wraps relation endpoints for traefik_route. The requirer of this
+relation is the traefik-route-k8s charm, or any charm capable of providing
+Traefik configuration files. The provider is the traefik-k8s charm, or another
+charm willing to consume Traefik configuration files.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route
+```
+
+To use the library from the provider side (Traefik):
+
+```yaml
+provides:
+    traefik_route:
+        interface: traefik_route
+        limit: 1
+```
+
+```python
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteProvider
+
+class TraefikCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.traefik_route = TraefikRouteProvider(self)
+
+    self.framework.observe(
+        self.traefik_route.on.ready, self._handle_traefik_route_ready
+    )
+
+    def _handle_traefik_route_ready(self, event):
+        config: str = self.traefik_route.get_config(event.relation)  # yaml
+        # use config to configure Traefik
+```
+
+To use the library from the requirer side (TraefikRoute):
+
+```yaml
+requires:
+    traefik-route:
+        interface: traefik_route
+        limit: 1
+        optional: false
+```
+
+Example usage without raw flag (default behavior):
+
+```python
+# ...
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
+
+class TraefikRouteCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    traefik_route = TraefikRouteRequirer(
+        self, self.model.relations.get("traefik-route"),
+        "traefik-route",
+        raw=False  # Default: Traefik will append TLS configs
+    )
+    if traefik_route.is_ready():
+        traefik_route.submit_to_traefik(
+            config={'my': {'traefik': 'configuration'}}
+        )
+```
+
+Example usage with raw flag enabled (full control over TLS configuration):
+
+```python
+# ...
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
+
+class TraefikRouteCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    traefik_route = TraefikRouteRequirer(
+        self, self.model.relations.get("traefik-route"),
+        "traefik-route",
+        raw=True  # Traefik will not modify TLS settings on all routes
+    )
+    if self.traefik_route.is_ready():
+        self.traefik_route.submit_to_traefik(
+            config={
+                'tcp': {
+                    'routers': {
+                        'secure-route': {
+                            'rule': 'Host(`secure.example.com`)',
+                            'service': 'my-service',
+                            'tls': {'certResolver': 'myresolver'}
+                        }
+                    }
+                }
+            }
+        )
+```
+"""
+import logging
+from typing import Optional
+
+import yaml
+from ops.charm import CharmBase, CharmEvents, RelationEvent
+from ops.framework import EventSource, Object, StoredState
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f0d93d2bdf354b99a527463a9c49fce3"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+log = logging.getLogger(__name__)
+
+
+class TraefikRouteException(RuntimeError):
+    """Base class for exceptions raised by TraefikRoute."""
+
+
+class UnauthorizedError(TraefikRouteException):
+    """Raised when the unit needs leadership to perform some action."""
+
+
+class TraefikRouteProviderReadyEvent(RelationEvent):
+    """Event emitted when Traefik is ready to provide ingress for a routed unit."""
+
+
+class TraefikRouteProviderDataRemovedEvent(RelationEvent):
+    """Event emitted when a routed ingress relation is removed."""
+
+
+class TraefikRouteRequirerReadyEvent(RelationEvent):
+    """Event emitted when a unit requesting ingress has provided all data Traefik needs."""
+
+
+class TraefikRouteRequirerEvents(CharmEvents):
+    """Container for TraefikRouteRequirer events."""
+
+    ready = EventSource(TraefikRouteRequirerReadyEvent)
+
+
+class TraefikRouteProviderEvents(CharmEvents):
+    """Container for TraefikRouteProvider events."""
+
+    ready = EventSource(TraefikRouteProviderReadyEvent)  # TODO rename to data_provided in v1
+    data_removed = EventSource(TraefikRouteProviderDataRemovedEvent)
+
+
+class TraefikRouteProvider(Object):
+    """Implementation of the provider of traefik_route.
+
+    This will presumably be owned by a Traefik charm.
+    The main idea is that Traefik will observe the `ready` event and, upon
+    receiving it, will fetch the config from the TraefikRoute's application databag,
+    apply it, and update its own app databag to let Route know that the ingress
+    is there.
+    The TraefikRouteProvider provides api to do this easily.
+    """
+
+    on = TraefikRouteProviderEvents()  # pyright: ignore
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = "traefik-route",
+        external_host: str = "",
+        *,
+        scheme: str = "http",
+    ):
+        """Constructor for TraefikRouteProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation relation_name to bind to
+                (defaults to "traefik-route").
+            external_host: The external host.
+            scheme: The scheme.
+        """
+        super().__init__(charm, relation_name)
+        self._stored.set_default(external_host=None, scheme=None)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        if (
+            self._stored.external_host != external_host  # pyright: ignore
+            or self._stored.scheme != scheme  # pyright: ignore
+        ):
+            # If traefik endpoint details changed, update
+            self.update_traefik_address(external_host=external_host, scheme=scheme)
+
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
+        )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.external_host or ""  # type: ignore
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this endpoint."""
+        return list(self._charm.model.relations[self._relation_name])
+
+    def _update_stored(self) -> None:
+        """Ensure that the stored data is up-to-date.
+
+        This is split out into a separate method since, in the case of multi-unit deployments,
+        removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
+        app data ensures that only the previous leader will know what it is. Separating it
+        allows for reuse both when the property is called and if the relation changes, so a
+        leader change where the new leader checks the property will do the right thing.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            if not relation.app:
+                self._stored.external_host = ""
+                self._stored.scheme = ""
+                return
+            external_host = relation.data[relation.app].get("external_host", "")
+            self._stored.external_host = (
+                external_host or self._stored.external_host  # pyright: ignore
+            )
+            scheme = relation.data[relation.app].get("scheme", "")
+            self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+
+    def _on_relation_changed(self, event: RelationEvent):
+        if self.is_ready(event.relation):
+            # todo check data is valid here?
+            self.update_traefik_address()
+            self.on.ready.emit(event.relation)
+
+    def _on_relation_broken(self, event: RelationEvent):
+        self.on.data_removed.emit(event.relation)
+
+    def update_traefik_address(
+        self, *, external_host: Optional[str] = None, scheme: Optional[str] = None
+    ):
+        """Ensure that requirers know the external host for Traefik."""
+        if not self._charm.unit.is_leader():
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.app]["external_host"] = external_host or self.external_host
+            relation.data[self._charm.app]["scheme"] = scheme or self.scheme
+
+        # We first attempt to write relation data (which may raise) and only then update stored
+        # state.
+        self._stored.external_host = external_host
+        self._stored.scheme = scheme
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Whether TraefikRoute is ready on this relation.
+
+        Returns True when the remote app shared the config; False otherwise.
+        """
+        if not relation.app or not relation.data[relation.app]:
+            return False
+        return "config" in relation.data[relation.app]
+
+    def get_config(self, relation: Relation) -> Optional[str]:
+        """Renamed to ``get_dynamic_config``."""
+        log.warning(
+            "``TraefikRouteProvider.get_config`` is deprecated. "
+            "Use ``TraefikRouteProvider.get_dynamic_config`` instead"
+        )
+        return self.get_dynamic_config(relation)
+
+    def get_dynamic_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the dynamic config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
+        return relation.data[relation.app].get("config")
+
+    def is_raw_enabled(self, relation: Relation) -> bool:
+        """Check if the raw config mode is enabled by the remote application."""
+        if not self.is_ready(relation):
+            return False
+        return relation.data[relation.app].get("raw") == "True"
+
+    def get_static_config(self, relation: Relation) -> Optional[str]:
+        """Retrieve the static config published by the remote application."""
+        if not self.is_ready(relation):
+            return None
+        return relation.data[relation.app].get("static")
+
+
+class TraefikRouteRequirer(Object):
+    """Handles the requirer side of the traefik-route interface.
+
+    This class provides an API for publishing dynamic and static configurations
+    to the Traefik charm through the `traefik-route` relation. It does not perform
+    validation on the provided configurations, assuming that Traefik will handle
+    valid YAML-encoded data.
+
+    The application databag follows the structure:
+
+    ```json
+    {
+        "config": "<Traefik dynamic config YAML>",
+        "static": "<Traefik static config YAML>",  # Optional, requires Traefik restart
+        "raw": "<bool>"  # Determines if Traefik should append TLS config for ALL routes
+    }
+    ```
+
+    """
+
+    on = TraefikRouteRequirerEvents()  # pyright: ignore
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation: Relation,
+        relation_name: str = "traefik-route",
+        raw: Optional[bool] = False,
+    ):
+        super(TraefikRouteRequirer, self).__init__(charm, relation_name)
+        self._stored.set_default(external_host=None, scheme=None)
+
+        self._charm = charm
+        self._relation = relation
+        self._raw = raw
+
+        if self._raw:
+            log.warning(
+                "Raw mode enabled: TLS routes for ALL protocols will not be auto-generated. "
+                "Enable this only if you fully understand and intend to bypass the additional TLS configuration."
+            )
+
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
+        )
+
+    @property
+    def external_host(self) -> str:
+        """Return the external host set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.external_host or ""  # type: ignore
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
+
+    def _update_stored(self) -> None:
+        """Ensure that the stored host is up-to-date.
+
+        This is split out into a separate method since, in the case of multi-unit deployments,
+        removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
+        app data ensures that only the previous leader will know what it is. Separating it
+        allows for reuse both when the property is called and if the relation changes, so a
+        leader change where the new leader checks the property will do the right thing.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        if self._relation:
+            for relation in self._charm.model.relations[self._relation.name]:
+                if not relation.app:
+                    self._stored.external_host = ""
+                    self._stored.scheme = ""
+                    return
+                external_host = relation.data[relation.app].get("external_host", "")
+                self._stored.external_host = (
+                    external_host or self._stored.external_host  # pyright: ignore
+                )
+                scheme = relation.data[relation.app].get("scheme", "")
+                self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+
+    def _on_relation_changed(self, event: RelationEvent) -> None:
+        """Update StoredState with external_host and other information from Traefik."""
+        self._update_stored()
+        if self._charm.unit.is_leader():
+            self.on.ready.emit(event.relation)
+
+    def _on_relation_broken(self, event: RelationEvent) -> None:
+        """On RelationBroken, clear the stored data if set and emit an event."""
+        self._stored.external_host = ""
+        if self._charm.unit.is_leader():
+            self.on.ready.emit(event.relation)
+
+    def is_ready(self) -> bool:
+        """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
+        return self._relation is not None
+
+    def submit_to_traefik(self, config: dict, static: Optional[dict] = None):
+        """Submit an ingress configuration to Traefik.
+
+        This method publishes dynamic and static configuration data to the
+        `traefik-route` relation, allowing Traefik to pick up and apply the settings.
+
+        - **Dynamic config (`config`)**: Defines routing rules for Traefik.
+        - **Static config (`static`)**: Requires a Traefik restart to take effect.
+
+        Raises:
+            UnauthorizedError: If the unit is not the leader.
+        """
+        if not self._charm.unit.is_leader():
+            raise UnauthorizedError()
+
+        app_databag = self._relation.data[self._charm.app]
+
+        app_databag["raw"] = str(self._raw)
+
+        # Traefik thrives on YAML, feels pointless to talk JSON to Route
+        app_databag["config"] = yaml.safe_dump(config)
+
+        if static:
+            app_databag["static"] = yaml.safe_dump(static)

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -128,7 +128,7 @@ class LitmusChaoscenterCharm(CharmBase):
     def _on_any_event(self, _: EventBase):
         """Common entry hook."""
         self._reconcile()
-        self._receive_backend_http_api.publish_endpoint(self._internal_frontend_url)
+        self._receive_backend_http_api.publish_endpoint(self._most_external_frontend_url)
 
     def _on_collect_unit_status(self, e: CollectStatusEvent):
         missing_relations = [

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -128,7 +128,9 @@ class LitmusChaoscenterCharm(CharmBase):
     def _on_any_event(self, _: EventBase):
         """Common entry hook."""
         self._reconcile()
-        self._receive_backend_http_api.publish_endpoint(self._most_external_frontend_url)
+        self._receive_backend_http_api.publish_endpoint(
+            self._most_external_frontend_url
+        )
 
     def _on_collect_unit_status(self, e: CollectStatusEvent):
         missing_relations = [
@@ -168,7 +170,9 @@ class LitmusChaoscenterCharm(CharmBase):
             self.nginx.reconcile()
         if self.unit.is_leader() and self.ingress.is_ready():
             self.ingress.submit_to_traefik(
-                ingress_config(self.model.name, self.app.name, self._tls_config is not None),
+                ingress_config(
+                    self.model.name, self.app.name, self._tls_config is not None
+                ),
                 static=static_ingress_config(),
             )
 

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -26,6 +26,9 @@ from coordinated_workers.nginx import (
 )
 
 from nginx_config import get_config
+from traefik_config import ingress_config, static_ingress_config
+
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 
 from litmus_libs import get_app_hostname
 from litmus_libs.interfaces.http_api import (
@@ -54,6 +57,11 @@ class LitmusChaoscenterCharm(CharmBase):
             charm=self,
             relationship_name=TLS_CERTIFICATES_ENDPOINT,
             certificate_requests=[self._certificate_request_attributes],
+        )
+        self.ingress = TraefikRouteRequirer(
+            self,
+            self.model.get_relation("ingress"),  # type: ignore
+            "ingress",
         )
 
         self.nginx = Nginx(
@@ -90,7 +98,19 @@ class LitmusChaoscenterCharm(CharmBase):
     # EVENT HANDLERS #
     ##################
     @property
-    def _frontend_url(self):
+    def frontend_url(self):
+        """Http server url; ingressed if available, else over fqdn."""
+        """Ingressed URL, if related to ingress, otherwise internal url."""
+        if (
+            self.ingress.is_ready()
+            and self.ingress.scheme
+            and self.ingress.external_host
+        ):
+            return f"{self.ingress.scheme}://{self.ingress.external_host}:8185"
+        return self._internal_frontend_url
+
+    @property
+    def _internal_frontend_url(self):
         """Internal (i.e. not ingressed) url."""
         protocol = "https" if self._tls_config else "http"
         return f"{protocol}://{get_app_hostname(self.app.name, self.model.name)}:8185"
@@ -108,7 +128,7 @@ class LitmusChaoscenterCharm(CharmBase):
     def _on_any_event(self, _: EventBase):
         """Common entry hook."""
         self._reconcile()
-        self._receive_backend_http_api.publish_endpoint(self._frontend_url)
+        self._receive_backend_http_api.publish_endpoint(self._internal_frontend_url)
 
     def _on_collect_unit_status(self, e: CollectStatusEvent):
         missing_relations = [
@@ -137,7 +157,7 @@ class LitmusChaoscenterCharm(CharmBase):
 
         # TODO: add pebble check to verify frontend is up
         #  https://github.com/canonical/litmus-operators/issues/36
-        e.add_status(ActiveStatus(f"Ready at {self._frontend_url}."))
+        e.add_status(ActiveStatus(f"Ready at {self.frontend_url}."))
 
     ###################
     # UTILITY METHODS #
@@ -146,6 +166,11 @@ class LitmusChaoscenterCharm(CharmBase):
         """Run all logic that is independent of what event we're processing."""
         if self.backend_url and self.auth_url:
             self.nginx.reconcile()
+        if self.unit.is_leader() and self.ingress.is_ready():
+            self.ingress.submit_to_traefik(
+                ingress_config(self.model.name, self.app.name),
+                static=static_ingress_config(),
+            )
 
     @property
     def _certificate_request_attributes(self) -> CertificateRequestAttributes:

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -168,7 +168,7 @@ class LitmusChaoscenterCharm(CharmBase):
             self.nginx.reconcile()
         if self.unit.is_leader() and self.ingress.is_ready():
             self.ingress.submit_to_traefik(
-                ingress_config(self.model.name, self.app.name),
+                ingress_config(self.model.name, self.app.name, self._tls_config is not None),
                 static=static_ingress_config(),
             )
 

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -99,8 +99,10 @@ class LitmusChaoscenterCharm(CharmBase):
     ##################
     @property
     def _most_external_frontend_url(self):
-        """Http server url; ingressed if available, else over fqdn."""
-        """Ingressed URL, if related to ingress, otherwise internal url."""
+        """Litmus ChaosCenter URL.
+        
+        Ingressed URL, if related to ingress, otherwise internal url.
+        """
         if (
             self.ingress.is_ready()
             and self.ingress.scheme

--- a/chaoscenter/src/charm.py
+++ b/chaoscenter/src/charm.py
@@ -98,7 +98,7 @@ class LitmusChaoscenterCharm(CharmBase):
     # EVENT HANDLERS #
     ##################
     @property
-    def frontend_url(self):
+    def _most_external_frontend_url(self):
         """Http server url; ingressed if available, else over fqdn."""
         """Ingressed URL, if related to ingress, otherwise internal url."""
         if (
@@ -157,7 +157,7 @@ class LitmusChaoscenterCharm(CharmBase):
 
         # TODO: add pebble check to verify frontend is up
         #  https://github.com/canonical/litmus-operators/issues/36
-        e.add_status(ActiveStatus(f"Ready at {self.frontend_url}."))
+        e.add_status(ActiveStatus(f"Ready at {self._most_external_frontend_url}."))
 
     ###################
     # UTILITY METHODS #

--- a/chaoscenter/src/nginx_config.py
+++ b/chaoscenter/src/nginx_config.py
@@ -21,15 +21,6 @@ from urllib.parse import urlparse, ParseResult
 logger = logging.getLogger(__name__)
 
 
-http_locations: List[NginxLocationConfig] = [
-    NginxLocationConfig(
-        path="/auth", backend="auth", rewrite=["^/auth(/.*)$", "$1", "break"]
-    ),
-    NginxLocationConfig(
-        path="/api", backend="backend", rewrite=["^/api(/.*)$", "$1", "break"]
-    ),
-]
-
 http_server_port = 8185
 
 

--- a/chaoscenter/src/nginx_config.py
+++ b/chaoscenter/src/nginx_config.py
@@ -106,6 +106,7 @@ def _generate_http_locations(
         NginxLocationConfig(
             path="/api",
             backend="backend",
+            rewrite=["^/api(/.*)$", "$1", "break"],
             upstream_tls=True if backend_scheme == "https" else False,
             extra_directives=_extra_directives(backend_scheme),
         ),

--- a/chaoscenter/src/nginx_config.py
+++ b/chaoscenter/src/nginx_config.py
@@ -20,6 +20,16 @@ from urllib.parse import urlparse, ParseResult
 
 logger = logging.getLogger(__name__)
 
+
+http_locations: List[NginxLocationConfig] = [
+    NginxLocationConfig(
+        path="/auth", backend="auth", rewrite=["^/auth(/.*)$", "$1", "break"]
+    ),
+    NginxLocationConfig(
+        path="/api", backend="backend", rewrite=["^/api(/.*)$", "$1", "break"]
+    ),
+]
+
 http_server_port = 8185
 
 

--- a/chaoscenter/src/traefik_config.py
+++ b/chaoscenter/src/traefik_config.py
@@ -1,0 +1,50 @@
+from collections import namedtuple
+import socket
+from typing import Dict, Sequence
+
+
+EntryPoint = namedtuple("Port", "name, port")
+
+
+def entrypoints() -> Sequence[EntryPoint]:
+    return (EntryPoint("parca-http", 8185),)
+
+
+def static_ingress_config() -> dict:
+    entry_points = {}
+    for name, port in entrypoints():
+        entry_points[name] = {"address": f":{port}"}
+
+    return {"entryPoints": entry_points}
+
+
+def _build_lb_server_config(scheme: str, port: int) -> Dict[str, str]:
+    """Build the server portion of the loadbalancer config of Traefik ingress."""
+    return {"url": f"{scheme}://{socket.getfqdn()}:{port}"}
+
+
+def ingress_config(model_name: str, app_name: str) -> dict:
+    """Build a raw ingress configuration for Traefik."""
+    http_routers = {}
+    http_services = {}
+    for name, port in entrypoints():
+        http_routers[f"juju-{model_name}-{app_name}-{name}"] = {
+            "entryPoints": [name],
+            "service": f"juju-{model_name}-{app_name}-service-{name}",
+            "rule": "ClientIP(`0.0.0.0/0`)",
+        }
+        # ref https://doc.traefik.io/traefik/v2.0/user-guides/grpc/#with-https
+        http_services[f"juju-{model_name}-{app_name}-service-{name}"] = {
+            "loadBalancer": {
+                "servers": [
+                    # TODO TLS: after https://github.com/canonical/litmus-operators/pull/44
+                    _build_lb_server_config("http", port)
+                ]
+            }
+        }
+    return {
+        "http": {
+            "routers": http_routers,
+            "services": http_services,
+        },
+    }

--- a/chaoscenter/src/traefik_config.py
+++ b/chaoscenter/src/traefik_config.py
@@ -23,7 +23,7 @@ def _build_lb_server_config(scheme: str, port: int) -> Dict[str, str]:
     return {"url": f"{scheme}://{socket.getfqdn()}:{port}"}
 
 
-def ingress_config(model_name: str, app_name: str) -> dict:
+def ingress_config(model_name: str, app_name: str, tls: bool) -> dict:
     """Build a raw ingress configuration for Traefik."""
     http_routers = {}
     http_services = {}
@@ -32,13 +32,13 @@ def ingress_config(model_name: str, app_name: str) -> dict:
             "entryPoints": [name],
             "service": f"juju-{model_name}-{app_name}-service-{name}",
             "rule": "ClientIP(`0.0.0.0/0`)",
+            # TODO do we need middlewares?
         }
         # ref https://doc.traefik.io/traefik/v2.0/user-guides/grpc/#with-https
         http_services[f"juju-{model_name}-{app_name}-service-{name}"] = {
             "loadBalancer": {
                 "servers": [
-                    # TODO TLS: after https://github.com/canonical/litmus-operators/pull/44
-                    _build_lb_server_config("http", port)
+                    _build_lb_server_config("https" if tls else "http", port)
                 ]
             }
         }

--- a/chaoscenter/src/traefik_config.py
+++ b/chaoscenter/src/traefik_config.py
@@ -37,9 +37,7 @@ def ingress_config(model_name: str, app_name: str, tls: bool) -> dict:
         # ref https://doc.traefik.io/traefik/v2.0/user-guides/grpc/#with-https
         http_services[f"juju-{model_name}-{app_name}-service-{name}"] = {
             "loadBalancer": {
-                "servers": [
-                    _build_lb_server_config("https" if tls else "http", port)
-                ]
+                "servers": [_build_lb_server_config("https" if tls else "http", port)]
             }
         }
     return {

--- a/chaoscenter/src/traefik_config.py
+++ b/chaoscenter/src/traefik_config.py
@@ -7,7 +7,7 @@ EntryPoint = namedtuple("Port", "name, port")
 
 
 def entrypoints() -> Sequence[EntryPoint]:
-    return (EntryPoint("parca-http", 8185),)
+    return (EntryPoint("litmus-chaoscenter", 8185),)
 
 
 def static_ingress_config() -> dict:

--- a/chaoscenter/src/traefik_config.py
+++ b/chaoscenter/src/traefik_config.py
@@ -23,18 +23,6 @@ def _build_lb_server_config(scheme: str, port: int) -> Dict[str, str]:
     return {"url": f"{scheme}://{socket.getfqdn()}:{port}"}
 
 
-def _redirect_middleware(name: str, port: int):
-    return {
-        f"{name}-redirect": {
-            "redirectScheme": {
-                "permanent": True,
-                "port": port,
-                "scheme": "https",
-            }
-        }
-    }
-
-
 def ingress_config(model_name: str, app_name: str, tls: bool) -> dict:
     """Build a raw ingress configuration for Traefik."""
     http_routers = {}
@@ -44,8 +32,6 @@ def ingress_config(model_name: str, app_name: str, tls: bool) -> dict:
             "entryPoints": [name],
             "service": f"juju-{model_name}-{app_name}-service-{name}",
             "rule": "ClientIP(`0.0.0.0/0`)",
-            **({"middlewares": [_redirect_middleware(name, port)]} if tls else {}),
-            # TODO do we need middlewares?
         }
         # ref https://doc.traefik.io/traefik/v2.0/user-guides/grpc/#with-https
         http_services[f"juju-{model_name}-{app_name}-service-{name}"] = {

--- a/chaoscenter/tests/unit/conftest.py
+++ b/chaoscenter/tests/unit/conftest.py
@@ -97,3 +97,9 @@ def ingress_relation():
     return Relation(
         "ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "http"}
     )
+
+@pytest.fixture
+def ingress_over_https_relation():
+    return Relation(
+        "ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "https"}
+    )

--- a/chaoscenter/tests/unit/conftest.py
+++ b/chaoscenter/tests/unit/conftest.py
@@ -98,6 +98,7 @@ def ingress_relation():
         "ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "http"}
     )
 
+
 @pytest.fixture
 def ingress_over_https_relation():
     return Relation(

--- a/chaoscenter/tests/unit/conftest.py
+++ b/chaoscenter/tests/unit/conftest.py
@@ -90,3 +90,10 @@ def backend_http_api_relation():
 @pytest.fixture
 def tls_certificates_relation():
     return Relation("tls-certificates")
+
+
+@pytest.fixture
+def ingress_relation():
+    return Relation(
+        "ingress", remote_app_data={"external_host": "1.2.3.4", "scheme": "http"}
+    )

--- a/chaoscenter/tests/unit/resources/sample_nginx_litmus_ssl.conf
+++ b/chaoscenter/tests/unit/resources/sample_nginx_litmus_ssl.conf
@@ -56,6 +56,7 @@ http {
         }
         location /api {
             set $backend https://backend;
+            rewrite '^/api(/.*)$' $1 break;
             proxy_pass $backend;
             proxy_connect_timeout 5s;
             proxy_ssl_verify off;

--- a/chaoscenter/tests/unit/test_ingress.py
+++ b/chaoscenter/tests/unit/test_ingress.py
@@ -10,7 +10,7 @@ def test_ingressed_url_present_in_status(
     backend_http_api_relation,
     ingress_relation,
 ):
-    # GIVEN http api relations with auth and backend
+    # GIVEN http api relations with auth and backend and ingress
     # WHEN any event happens
     state_out = ctx.run(
         ctx.on.update_status(),

--- a/chaoscenter/tests/unit/test_ingress.py
+++ b/chaoscenter/tests/unit/test_ingress.py
@@ -1,0 +1,29 @@
+from scenario import State
+
+import ops
+
+
+def test_ingressed_url_present_in_status(
+    ctx,
+    nginx_container,
+    auth_http_api_relation,
+    backend_http_api_relation,
+    ingress_relation,
+):
+    # GIVEN http api relations with auth and backend
+    # WHEN any event happens
+    state_out = ctx.run(
+        ctx.on.update_status(),
+        state=State(
+            leader=True,
+            relations={
+                auth_http_api_relation,
+                backend_http_api_relation,
+                ingress_relation,
+            },
+            containers={nginx_container},
+        ),
+    )
+
+    # THEN juju status reports an ingressed url
+    assert state_out.unit_status == ops.ActiveStatus("Ready at http://1.2.3.4:8185.")

--- a/chaoscenter/tests/unit/test_ingress.py
+++ b/chaoscenter/tests/unit/test_ingress.py
@@ -27,3 +27,33 @@ def test_ingressed_url_present_in_status(
 
     # THEN juju status reports an ingressed url
     assert state_out.unit_status == ops.ActiveStatus("Ready at http://1.2.3.4:8185.")
+
+
+def test_ingressed_https_url_present_in_status(
+    ctx,
+    nginx_container,
+    auth_http_api_relation,
+    backend_http_api_relation,
+    ingress_over_https_relation,
+    tls_certificates_relation,
+    patch_cert_and_key,
+    patch_write_to_ca_path,
+):
+    # GIVEN http api relations with auth and backend and ingress
+    # WHEN any event happens
+    state_out = ctx.run(
+        ctx.on.update_status(),
+        state=State(
+            leader=True,
+            relations={
+                auth_http_api_relation,
+                backend_http_api_relation,
+                ingress_over_https_relation,
+                tls_certificates_relation,
+            },
+            containers={nginx_container},
+        ),
+    )
+
+    # THEN juju status reports an ingressed url
+    assert state_out.unit_status == ops.ActiveStatus("Ready at https://1.2.3.4:8185.")

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -1,31 +1,17 @@
-import shlex
 import subprocess
 import pytest
 from helpers import (
     deploy_control_plane,
     CHAOSCENTER_APP,
-    AUTH_APP,
-    MONGO_APP,
-    BACKEND_APP,
+    TRAEFIK_APP,
     get_unit_ip_address,
 )
-from jubilant import Juju, all_active, any_error, all_blocked
-
-
-TRAEFIK_APP = "traefik"
+from jubilant import Juju, all_active, any_error
 
 
 @pytest.mark.setup
 def test_setup(juju: Juju):
-    deploy_control_plane(juju, wait_for_idle=True)
-    juju.deploy("traefik-k8s", channel="latest/edge", app=TRAEFIK_APP, trust=True)
-    juju.wait(
-        lambda status: all_active(status, TRAEFIK_APP),
-        error=lambda status: any_error(status, TRAEFIK_APP),
-        timeout=1000,
-        delay=10,
-        successes=6,
-    )
+    deploy_control_plane(juju, wait_for_idle=True, with_traefik=True)
 
 
 def test_litmus_is_served_over_ingress(juju: Juju):
@@ -44,24 +30,8 @@ def test_litmus_is_served_over_ingress(juju: Juju):
     )
 
     traefik_ip = get_unit_ip_address(juju, TRAEFIK_APP, 0)
-    cmd = f"curl -X GET http://{traefik_ip}:8185"
-    result = subprocess.run(shlex.split(cmd), text=True, capture_output=True)
+    cmd = f"curl -sS -X GET http://{traefik_ip}:8185"
+    result = subprocess.getoutput(cmd)
 
     # THEN we receive a response that is served by the frontend
-    assert "LitmusChaos" in result.stdout
-
-
-@pytest.mark.teardown
-def test_teardown(juju: Juju):
-    juju.remove_relation(CHAOSCENTER_APP, TRAEFIK_APP)
-    juju.remove_relation(AUTH_APP, MONGO_APP)
-    juju.remove_relation(BACKEND_APP, MONGO_APP)
-    juju.remove_relation(BACKEND_APP, AUTH_APP)
-
-    juju.wait(
-        lambda status: all_blocked(status, AUTH_APP, BACKEND_APP),
-        error=lambda status: any_error(status, AUTH_APP, BACKEND_APP),
-        timeout=1000,
-        delay=10,
-        successes=6,
-    )
+    assert "LitmusChaos" in result

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -18,7 +18,6 @@ def test_litmus_is_served_over_ingress(juju: Juju):
     # GIVEN a deployment of control plane with traefik
 
     # WHEN traefik and litmus are related
-    juju.integrate(f"{CHAOSCENTER_APP}:ingress", TRAEFIK_APP)
 
     # THEN it's possible to reach Litmus through the ingress
     juju.wait(

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -1,0 +1,67 @@
+import shlex
+import subprocess
+import pytest
+from helpers import (
+    deploy_control_plane,
+    CHAOSCENTER_APP,
+    AUTH_APP,
+    MONGO_APP,
+    BACKEND_APP,
+    get_unit_ip_address,
+)
+from jubilant import Juju, all_active, any_error, all_blocked
+
+
+TRAEFIK_APP = "traefik"
+
+
+@pytest.mark.setup
+def test_setup(juju: Juju):
+    deploy_control_plane(juju, wait_for_idle=True)
+    juju.deploy("traefik-k8s", channel="latest/edge", app=TRAEFIK_APP, trust=True)
+    juju.wait(
+        lambda status: all_active(status, TRAEFIK_APP),
+        error=lambda status: any_error(status, TRAEFIK_APP),
+        timeout=1000,
+        delay=10,
+        successes=6,
+    )
+
+
+def test_litmus_is_served_over_ingress(juju: Juju):
+    # GIVEN a deployment of control plane with traefik
+
+    # WHEN traefik and litmus are related
+    juju.integrate(f"{CHAOSCENTER_APP}:ingress", TRAEFIK_APP)
+
+    # THEN it's possible to reach Litmus through the ingress
+    juju.wait(
+        lambda status: all_active(status, TRAEFIK_APP, CHAOSCENTER_APP),
+        error=lambda status: any_error(status, TRAEFIK_APP, CHAOSCENTER_APP),
+        timeout=1000,
+        delay=10,
+        successes=6,
+    )
+
+    traefik_ip = get_unit_ip_address(juju, TRAEFIK_APP, 0)
+    cmd = f"curl -X GET http://{traefik_ip}:8185"
+    result = subprocess.run(shlex.split(cmd), text=True, capture_output=True)
+
+    # THEN we receive a response that is served by the frontend
+    assert "LitmusChaos" in result.stdout
+
+
+@pytest.mark.teardown
+def test_teardown(juju: Juju):
+    juju.remove_relation(CHAOSCENTER_APP, TRAEFIK_APP)
+    juju.remove_relation(AUTH_APP, MONGO_APP)
+    juju.remove_relation(BACKEND_APP, MONGO_APP)
+    juju.remove_relation(BACKEND_APP, AUTH_APP)
+
+    juju.wait(
+        lambda status: all_blocked(status, AUTH_APP, BACKEND_APP),
+        error=lambda status: any_error(status, AUTH_APP, BACKEND_APP),
+        timeout=1000,
+        delay=10,
+        successes=6,
+    )

--- a/tests/integration/test_ingress_with_ssl.py
+++ b/tests/integration/test_ingress_with_ssl.py
@@ -31,7 +31,7 @@ def test_setup(juju: Juju):
     deploy_control_plane(juju, with_tls=True, with_traefik=True, wait_for_idle=True)
 
 
-def test_frontend_is_served_with_ssl(juju: Juju):
+def test_frontend_is_served_through_traefik_with_ssl(juju: Juju):
     # GIVEN control plane is deployed and TLS is enabled
 
     # WHEN we call the frontend over https

--- a/tests/integration/test_ingress_with_ssl.py
+++ b/tests/integration/test_ingress_with_ssl.py
@@ -65,7 +65,7 @@ def test_backend_is_served_through_nginx_with_ssl(juju: Juju, token):
     subprocess.check_call(shlex.split(cmd))
 
 
-def test_auth_is_served_through_nginx_with_ssl(juju: Juju):
+def test_auth_is_served_through_traefik_with_ssl(juju: Juju):
     # GIVEN control plane is deployed and TLS is enabled
 
     # WHEN we call the nginx redirect for auth server

--- a/tests/integration/test_ingress_with_ssl.py
+++ b/tests/integration/test_ingress_with_ssl.py
@@ -43,7 +43,7 @@ def test_frontend_is_served_with_ssl(juju: Juju):
     assert "LitmusChaos" in result
 
 
-def test_backend_is_served_through_nginx_with_ssl(juju: Juju, token):
+def test_backend_is_served_through_traefik_with_ssl(juju: Juju, token):
     # GIVEN control plane is deployed and TLS is enabled
 
     # WHEN we call the nginx redirect for backend iver traefik

--- a/tests/integration/test_ingress_with_ssl.py
+++ b/tests/integration/test_ingress_with_ssl.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+import logging
+import shlex
+import subprocess
+import pytest
+from jubilant import Juju
+from helpers import (
+    deploy_control_plane,
+    CHAOSCENTER_APP,
+    TRAEFIK_APP,
+    get_unit_ip_address,
+    get_login_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def token(juju: Juju):
+    chaoscenter_ip = get_unit_ip_address(juju, CHAOSCENTER_APP, 0)
+    _, out = get_login_response(
+        host=chaoscenter_ip, port=8185, subpath="/auth", use_ssl=True
+    )
+    return json.loads(out)["accessToken"]
+
+
+@pytest.mark.setup
+def test_setup(juju: Juju):
+    deploy_control_plane(juju, with_tls=True, with_traefik=True, wait_for_idle=True)
+
+
+def test_frontend_is_served_with_ssl(juju: Juju):
+    # GIVEN control plane is deployed and TLS is enabled
+
+    # WHEN we call the frontend over https
+    traefik_ip = get_unit_ip_address(juju, TRAEFIK_APP, 0)
+    cmd = f"curl -k -sS -X GET https://{traefik_ip}:8185"
+    result = subprocess.getoutput(cmd)
+
+    # THEN we receive a response that is served by the frontend
+    assert "LitmusChaos" in result
+
+
+def test_backend_is_served_through_nginx_with_ssl(juju: Juju, token):
+    # GIVEN control plane is deployed and TLS is enabled
+
+    # WHEN we call the nginx redirect for backend iver traefik
+    traefik_ip = get_unit_ip_address(juju, TRAEFIK_APP, 0)
+    query = (
+        'mutation { createEnvironment(projectID:"", '
+        'request:{environmentID:"test-env-1", name:"My Test Environment", type:NON_PROD}) '
+        "{ environmentID name type } }"
+    )
+
+    cmd = (
+        'curl -sS -k -X POST -H "Content-Type: application/json" '
+        f'-H "Authorization: Bearer {token}" '
+        f'-d \'{{"query": "{query}"}}\' '
+        f"https://{traefik_ip}:8185/backend/query"
+    )
+
+    # THEN we receive a response from the backend
+    subprocess.check_call(shlex.split(cmd))
+
+
+def test_auth_is_served_through_nginx_with_ssl(juju: Juju):
+    # GIVEN control plane is deployed and TLS is enabled
+
+    # WHEN we call the nginx redirect for auth server
+    traefik_ip = get_unit_ip_address(juju, TRAEFIK_APP, 0)
+    returncode, output = get_login_response(
+        host=traefik_ip,
+        port=8185,
+        subpath="/auth",
+        use_ssl=True,
+    )
+
+    # THEN we receive a response from the auth server
+    assert returncode == 0
+    response_json = json.loads(output)
+    assert "accessToken" in response_json, f"No token found in response: {output}"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There was no ingress support in chaoscenter control plane so far.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add ingress using traefik-route so that the frontend is served regardless of the subpath. Closes #38.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

### Why traefik-route, when we try to avoid it?

Litmus frontend isn't able to be served on a subpath - see https://github.com/litmuschaos/litmus/issues/3323 . I've tested deploying with a custom rock based on a webpack change to allow subpath deployment: https://github.com/litmuschaos/litmus/compare/master...mmkay:litmus:feat/auto-base-url - although it was able to load the js files, it errored out with a 404. Also, to use such a fix we'd need to wait for an upstream merge and a new version release.

### Where are the styles?

It doesn't seem to be related, so I created #46 to handle that.

### Drive-bys

Turned out backend actually also needs a rewrite to work, so I added the rewrite here as well.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Run the integration tests with `--keep-models`:

```
tox -re integration -- -k test_ingress --keep-models
```

Then use the deployed model to access chaoscenter through traefik.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
