### PR TITLE
chore: remove unneeded todos

### DIFF
--- a/auth/src/litmus_auth.py
+++ b/auth/src/litmus_auth.py
@@ -79,7 +79,8 @@ class LitmusAuth:
             "REST_PORT": self.http_port,
             "GRPC_PORT": self.grpc_port,
             # default admin credentials to login to the litmus portal for the 1st time
-            # TODO: perhaps these should come from config options https://github.com/canonical/litmus-operators/issues/18
+            # Users are prompted to change the password after their first login, so we document
+            # this behavior instead of managing state ourselves.
             "ADMIN_USERNAME": "admin",
             "ADMIN_PASSWORD": "litmus",
         }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -112,7 +112,6 @@ def get_login_response(
     allow_insecure = "-k" if use_ssl else ""
     cmd = (
         f'curl {allow_insecure} -sS -X POST -H "Content-Type: application/json" '
-        # TODO: fetch from config options once https://github.com/canonical/litmus-operators/issues/18 is fixed
         '-d \'{"username": "admin", "password": "litmus"}\' '
         f"{protocol}://{host}:{port}{subpath}/login"
     )


### PR DESCRIPTION
Remove the todos related to https://github.com/canonical/litmus-operators/issues/18 after deciding not to go with this change
