### PR TITLE
fix: Adds missing outputs.tf file to the solution module

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "auth_app_name" {
+  description = "Name of the deployed Litmus Auth application."
+  value       = module.auth.app_name
+}
+
+output "backend_app_name" {
+  description = "Name of the deployed Litmus Backend application."
+  value       = module.backend.app_name
+}
+
+output "chaoscenter_app_name" {
+  description = "Name of the deployed Litmus ChaosCenter application."
+  value       = module.chaoscenter.app_name
+}


### PR DESCRIPTION
Adds missing `outputs.tf` file to the solution module.

This file is needed to reference deployed Chamed Litmus applications in the higher level modules.