### PR TITLE
chore: Adds tests for the TF module

### DIFF
--- a/.github/workflows/_terraform-tests-auto.yaml
+++ b/.github/workflows/_terraform-tests-auto.yaml
@@ -1,0 +1,62 @@
+name: Terraform module tests (auto)
+
+on:
+  workflow_call:
+    inputs:
+      terraform-module-path:
+        description: "CWD for this test; path to a dir with a main.tf file."
+        default: 'terraform'
+        required: false
+        type: string
+      terraform-args:
+        description: "Additional arguments (such as additional -var) to pass to `terraform apply`."
+        default: ''
+        required: false
+        type: string
+      charm-channel:
+        description: "Charm channel to deploy from with the terraform module"
+        default: '2/edge'
+        required: false
+        type: string
+      provider:
+        description: |
+          The substrate to set up prior to running the test 
+          (a concierge preset, e.g. 'machine' or 'microk8s').
+        default: 'microk8s'
+        required: false
+        type: string
+      active-timeout:
+        description: |
+          How many seconds to wait for the model to get to active after terraform deploy.
+        default: 1200 # 20 minutes
+        required: false
+        type: string
+
+jobs:
+    tf-tests:
+        runs-on: [self-hosted]
+        name: Terraform tests
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+          - name: Install dependencies
+            run: |
+              sudo snap install concierge --classic
+              sudo concierge prepare -p ${{ inputs.provider }} --extra-snaps terraform,astral-uv
+
+          - name: Run tests
+            run: |
+              export MODEL="test-terraform"
+              juju add-model $MODEL
+              
+              cd ${{ inputs.terraform-module-path }}
+  
+              terraform init
+              terraform apply \
+                -var="channel=${{ inputs.charm-channel }}" \
+                -var="model=$MODEL" ${{ inputs.terraform-args || '' }} -auto-approve 
+                
+              # assert all gets to active; eventually
+              uv run --with jubilant python -c "import jubilant as j; j.Juju(model='$MODEL').wait(j.all_active, timeout=${{ inputs.active-timeout }})"
+              
+              juju destroy-model --no-prompt test-terraform --no-wait --force  

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -1,0 +1,20 @@
+name: Terraform module tests
+
+on:
+    workflow_dispatch:
+    schedule:
+      - cron: "0 0 7,14,21 * *"
+#              │ │    │    │ │
+#              │ │    │    │ └──── any day of the week.
+#              │ │    │    └────── any month.
+#              │ │    └─────────── 7th, 14th, 21st day of the month.
+#              │ └──────────────── 0th hour of the day.
+#              └────────────────── Start of the hour (minutes = 0).
+
+jobs:
+  terraform-tests:
+    name: Run terraform tests
+    uses: ./.github/workflows/_terraform-tests-auto.yaml
+    with:
+      charm-channel: 2/edge
+    secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ We are using the following images built by [oci-factory](https://github.com/cano
 ### Testing
 
 ```shell
-tox -e fmt           # update your code according to formatting rules
+tox -e fmt           # update your code according to formatting rules; requires `opentofu` classic snap
 tox -e lint          # lint the codebase
 tox -e unit          # run the unit testing suite
 tox -e integration   # run the integration testing suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,16 @@
 name = "litmus-k8s"
 version = "0.1"  # this is in fact irrelevant
 requires-python = ">=3.12, <4"
+dependencies = []
 
 [dependency-groups]
 dev = [
     # itests
     "jubilant >=1",
+    "pytest-bdd>=8.1.0",
     "pytest-jubilant ~=1.0",
     "tenacity",
-    ]
+]
 
 unittest = [
     "pytest",

--- a/terraform/external/mongodb-k8s/main.tf
+++ b/terraform/external/mongodb-k8s/main.tf
@@ -1,0 +1,42 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "mongodb-k8s" {
+
+  charm {
+    name     = "mongodb-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = "ubuntu@22.04"
+  }
+  config      = var.config
+  model       = var.model
+  name        = var.app_name
+  units       = var.units
+  constraints = var.constraints
+  trust       = true
+
+
+  # TODO: uncomment once final fixes have been added for:
+  # Error: juju/terraform-provider-juju#443, juju/terraform-provider-juju#182
+  # placement = join(",", var.machines)
+
+  endpoint_bindings = [
+    for k, v in var.endpoint_bindings : {
+      endpoint = k, space = v
+    }
+  ]
+
+  storage_directives = var.storage
+
+  lifecycle {
+    precondition {
+      condition     = length(var.machines) == 0 || length(var.machines) == var.units
+      error_message = "Machine count does not match unit count"
+    }
+    precondition {
+      condition     = length(var.storage) == 0 || lookup(var.storage, "count", 0) <= 1
+      error_message = "Only one storage is supported"
+    }
+  }
+}

--- a/terraform/external/mongodb-k8s/outputs.tf
+++ b/terraform/external/mongodb-k8s/outputs.tf
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.mongodb-k8s.name
+}
+
+# Provided integration endpoints
+
+output "database_endpoint" {
+  description = "Name of the endpoint to provide the mongodb_client interface."
+  value       = "database"
+}
+
+output "cos_agent_endpoint" {
+  description = "Name of the endpoint to provide the cos_agent interface."
+  value       = "cos-agent"
+}
+
+output "config_server_endpoint" {
+  description = "Name of the endpoint to provide the shards interface."
+  value       = "config-server"
+}
+
+output "cluster_endpoint" {
+  description = "Name of the endpoint to provide the config-server interface."
+  value       = "cluster"
+}
+
+# Required integration endpoints
+
+output "certificates_endpoint" {
+  description = "Name of the endpoint to provide the tls-certificates interface."
+  value       = "certificates"
+}
+
+output "s3_credentials_endpoint" {
+  description = "Name of the endpoint to provide the s3 interface."
+  value       = "s3-credentials"
+}
+
+output "sharding_endpoint" {
+  description = "Name of the endpoint to provide the shards interface."
+  value       = "sharding"
+}

--- a/terraform/external/mongodb-k8s/variables.tf
+++ b/terraform/external/mongodb-k8s/variables.tf
@@ -1,0 +1,63 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "mongodb-k8s"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "6/stable"
+}
+
+
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model" {
+  description = "Model name"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Charm units"
+  type        = number
+  default     = 3
+}
+
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "machines" {
+  description = "List of machines for placement"
+  type        = list(string)
+  default     = []
+}
+
+variable "storage" {
+  description = "Map of storage used by the application"
+  type        = map(string)
+  default     = {}
+}
+
+variable "endpoint_bindings" {
+  description = "Map of endpoint bindings"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/external/mongodb-k8s/versions.tf
+++ b/terraform/external/mongodb-k8s/versions.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,10 +30,10 @@ module "chaoscenter" {
 }
 
 module "mongodb" {
-  source     = "git::https://github.com/canonical/mongodb-k8s-operator//terraform"
-  model      = data.juju_model.charmed-litmus.name
-  channel    = var.mongodb_channel
-  config     = var.mongodb_config
+  source  = "./external/mongodb-k8s"
+  model   = data.juju_model.charmed-litmus.name
+  channel = var.mongodb_channel
+  config  = var.mongodb_config
 }
 
 # Juju integrations

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -1,0 +1,8 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+module "litmus" {
+  source         = "../../terraform"
+  model          = var.model
+  litmus_channel = "2/edge"
+}

--- a/tests/terraform/test_terraform_module.py
+++ b/tests/terraform/test_terraform_module.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+import pathlib
+import subprocess
+import jubilant
+import pytest
+
+from pytest_bdd import given, when, then
+
+logger = logging.getLogger(__name__)
+
+TESTS_DIR = pathlib.Path(__file__).parent.resolve()
+
+
+@pytest.fixture
+def juju():
+    with jubilant.temp_model() as tm:
+        yield tm
+
+
+@given("a juju model")
+@when("you run terraform apply using the provided module")
+def test_terraform_apply(juju):
+    subprocess.check_call(["terraform", f"-chdir={TESTS_DIR}", "init"])
+    subprocess.check_call(
+        f"terraform -chdir={TESTS_DIR} apply -var \"model={juju.model}\" -auto-approve",
+        shell=True,
+    )
+
+
+@then("litmus charms are deployed and active")
+def test_active(juju):
+    juju.wait(jubilant.all_active, timeout=60 * 10)

--- a/tests/terraform/variables.tf
+++ b/tests/terraform/variables.tf
@@ -1,0 +1,7 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model" {
+  description = "Model name to deploy the charm to"
+  type        = string
+}

--- a/tests/terraform/versions.tf
+++ b/tests/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ description = Format all components
 setenv =
   PYTHONPATH = {toxinidir}
 allowlist_externals =
+    tofu
     tox
     uv
 commands =
@@ -62,6 +63,8 @@ commands =
     tox -c auth/tox.ini --root auth -e fmt
     tox -c chaoscenter/tox.ini --root chaoscenter -e fmt
     tox -c libs/tox.ini --root libs -e fmt
+    # terraform files formatting; requires opentofu snap (classic)
+    tofu fmt -recursive
 
 [testenv:static]
 description = Static checks on all components
@@ -105,3 +108,9 @@ setenv =
   PYTHONPATH = {toxinidir}
 commands =
     uv run {[vars]uv_flags} --group integration-tests pytest --exitfirst {[vars]tst_path}integration {posargs}
+
+
+[testenv:terraform]
+description = Run terraform tests
+commands =
+    uv run {[vars]uv_flags} pytest --exitfirst {[vars]tst_path}/terraform {posargs}

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -195,6 +204,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "jubilant" },
+    { name = "pytest-bdd" },
     { name = "pytest-jubilant" },
     { name = "tenacity" },
 ]
@@ -215,6 +225,7 @@ unittest = [
 [package.metadata.requires-dev]
 dev = [
     { name = "jubilant", specifier = ">=1" },
+    { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-jubilant", specifier = "~=1.0" },
     { name = "tenacity" },
 ]
@@ -226,6 +237,56 @@ type-checking = [
 unittest = [
     { name = "pytest" },
     { name = "pytest-cov" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -318,6 +379,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
 ]
 
 [[package]]
@@ -425,6 +508,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -490,6 +591,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds tests for Charmed Litmus solution level TF module.

To work around the issues in the official MongoDB module, custom module has been added.
https://github.com/canonical/mongodb-k8s-operator/issues/424
https://github.com/canonical/mongodb-k8s-operator/issues/425
