### PR TITLE
fix: Strips the workload_version variable

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,1 +1,0 @@
-model = "litmus"


### PR DESCRIPTION
Strips the workload_version variable to make sure there's no leading or trailing non-printable chars.

This PR fixes the string conversion error which prevented Litmus envs from being activated.