### PR TITLE
fix: Strips get_litmus_version output

### DIFF
--- a/libs/src/litmus_libs/utils.py
+++ b/libs/src/litmus_libs/utils.py
@@ -41,4 +41,4 @@ def get_litmus_version(container: Container) -> Optional[str]:
     if not container.exists(version_file_path):
         logger.warning("Version file not found at %s", version_file_path)
         return None
-    return container.pull(version_file_path, encoding="utf-8").read()
+    return container.pull(version_file_path, encoding="utf-8").read().strip()


### PR DESCRIPTION
Strips get_litmus_version output to make sure there's no leading or trailing non-printable chars.

This PR fixes the string conversion error which prevented Litmus envs from being activated.