### PR TITLE
chore: Move to using Canonical-provided rocks

### DIFF
--- a/backend/src/litmus_backend.py
+++ b/backend/src/litmus_backend.py
@@ -105,8 +105,22 @@ class LitmusBackend:
             },
         }
 
+    @staticmethod
+    def _docker_hub_tag(workload_version: str) -> str:
+        """Convert a Litmus workload version to a Docker Hub Ubuntu rock tag.
+
+        E.g. '3.26.0' -> '3.26-24.04_edge', '' -> '3-24.04_edge'.
+        """
+        if not workload_version:
+            return "3-24.04_edge"
+        parts = workload_version.split(".")
+        if len(parts) >= 2:
+            return f"{parts[0]}.{parts[1]}-24.04_edge"
+        return f"{parts[0]}-24.04_edge"
+
     def _environment_vars(self, tls_enabled: bool) -> dict:
         workload_version = self._workload_version or ""
+        image_tag = self._docker_hub_tag(workload_version)
         env = {
             "REST_PORT": self.http_port,
             "GRPC_PORT": self.grpc_port,
@@ -118,14 +132,13 @@ class LitmusBackend:
             # are there other versions we should set along with the current workload version?
             "INFRA_COMPATIBLE_VERSIONS": json.dumps([workload_version]),
             "VERSION": workload_version,
-            # TODO: use the rocks https://github.com/canonical/litmus-operators/issues/15
-            "SUBSCRIBER_IMAGE": f"litmuschaos/litmusportal-subscriber:{workload_version}",
-            "EVENT_TRACKER_IMAGE": f"litmuschaos/litmusportal-event-tracker:{workload_version}",
+            "SUBSCRIBER_IMAGE": f"ubuntu/litmuschaos-subscriber:{image_tag}",
+            "EVENT_TRACKER_IMAGE": f"ubuntu/litmuschaos-event-tracker:{image_tag}",
             "ARGO_WORKFLOW_CONTROLLER_IMAGE": "litmuschaos/workflow-controller:v3.3.1",
             "ARGO_WORKFLOW_EXECUTOR_IMAGE": "litmuschaos/argoexec:v3.3.1",
-            "LITMUS_CHAOS_OPERATOR_IMAGE": f"litmuschaos/chaos-operator:{workload_version}",
-            "LITMUS_CHAOS_RUNNER_IMAGE": f"litmuschaos/chaos-runner:{workload_version}",
-            "LITMUS_CHAOS_EXPORTER_IMAGE": f"litmuschaos/chaos-exporter:{workload_version}",
+            "LITMUS_CHAOS_OPERATOR_IMAGE": f"ubuntu/litmuschaos-operator:{image_tag}",
+            "LITMUS_CHAOS_RUNNER_IMAGE": f"ubuntu/litmuschaos-runner:{image_tag}",
+            "LITMUS_CHAOS_EXPORTER_IMAGE": f"ubuntu/litmuschaos-exporter:{image_tag}",
         }
 
         if db_config := self._db_config:

--- a/backend/tests/unit/test_pebble_plan.py
+++ b/backend/tests/unit/test_pebble_plan.py
@@ -10,6 +10,7 @@ from conftest import (
     http_api_remote_databag,
     patch_cert_and_key_ctx,
 )
+from litmus_backend import LitmusBackend
 
 
 def test_pebble_plan_minimal(ctx, backend_container):
@@ -214,6 +215,64 @@ def test_workload_version_in_pebble_env_vars(
             assert "1.0" in actual_env_vars[key]
         else:
             assert "1.0" not in actual_env_vars[key]
+
+
+@pytest.mark.parametrize(
+    "workload_version, expected_tag",
+    [
+        # typical 3-part version: strip patch, append ubuntu suffix
+        ("3.26.0", "3.26-24.04_edge"),
+        ("3.7.1",  "3.7-24.04_edge"),
+        # 2-part version: use as-is with suffix
+        ("3.26",   "3.26-24.04_edge"),
+        # 1-part version: major only
+        ("3",      "3-24.04_edge"),
+        # empty string: fall back to major-only default
+        ("",       "3-24.04_edge"),
+    ],
+)
+def test_docker_hub_tag(workload_version, expected_tag):
+    # GIVEN a workload version string
+    # WHEN converted to a Docker Hub Ubuntu rock tag
+    tag = LitmusBackend._docker_hub_tag(workload_version)
+    # THEN the tag matches the expected format
+    assert tag == expected_tag
+
+
+@pytest.mark.parametrize(
+    "workload_version, expected_tag",
+    [
+        ("3.26.0", "3.26-24.04_edge"),
+        ("3.7.1",  "3.7-24.04_edge"),
+    ],
+)
+def test_execution_plane_image_tags_in_pebble_plan(
+    ctx, backend_container, patch_workload_version, workload_version, expected_tag
+):
+    patch_workload_version.return_value = workload_version
+    execution_plane_images = {
+        "SUBSCRIBER_IMAGE":          f"ubuntu/litmuschaos-subscriber:{expected_tag}",
+        "EVENT_TRACKER_IMAGE":       f"ubuntu/litmuschaos-event-tracker:{expected_tag}",
+        "LITMUS_CHAOS_OPERATOR_IMAGE": f"ubuntu/litmuschaos-operator:{expected_tag}",
+        "LITMUS_CHAOS_RUNNER_IMAGE": f"ubuntu/litmuschaos-runner:{expected_tag}",
+        "LITMUS_CHAOS_EXPORTER_IMAGE": f"ubuntu/litmuschaos-exporter:{expected_tag}",
+    }
+
+    # GIVEN a running container
+    state = State(containers=[backend_container])
+
+    # WHEN any event is fired
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    actual_env_vars = state_out.get_container(backend_container.name).plan.to_dict()[
+        "services"
+    ]["backend"]["environment"]
+
+    # THEN each execution-plane image uses the correct ubuntu/ Docker Hub tag
+    for key, expected_image in execution_plane_images.items():
+        assert actual_env_vars[key] == expected_image, (
+            f"{key}: expected {expected_image!r}, got {actual_env_vars[key]!r}"
+        )
 
 
 @pytest.mark.parametrize("tls", (False, True))

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,15 +54,20 @@ def _charm_and_channel_and_resources(
         charm = f"litmus-{role}-k8s"
         logger.info(f"Using published {charm} charm from {channel_from_env}")
         return charm, channel_from_env, None
-    # else deploy from a charm packed locally
+    # deploy from a charm path specified explicitly for this role
     elif path_from_env := os.getenv(charm_path_key):
         charm_path = Path(path_from_env).absolute()
-        logger.info("Using local {role} charm: %s", charm_path)
+        logger.info("Using local %s charm: %s", role, charm_path)
         return (
             charm_path,
             None,
             get_resources(charm_path.parent),
         )
+    # deploy from the generic CHARM_PATH (set by CI for the charm under test)
+    elif (generic_path := os.getenv("CHARM_PATH")) and role in Path(generic_path).name:
+        charm_path = Path(generic_path).absolute()
+        logger.info("Using CHARM_PATH for %s: %s", role, charm_path)
+        return charm_path, None, get_resources(charm_path.parent)
     # else pack the charm
     charm_dir = REPO_ROOT / role
     return pack(charm_dir), None, get_resources(charm_dir)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We were using upstream images for components of the execution plane that are spinned up dynamically.

## Solution
<!-- A summary of the solution addressing the above issue -->
Use the Canonical provided rocks. Closes #15 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
We cannot move to our Argo rocks because the upstream has a heavy dependency on Argo Workflows 3.3. This wil be taken up with the upstream.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
I have done manual testing on the experiments. The CI should cover most of the test cases.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
