### PR TITLE
chore(ci): bump reusable workflows to v2

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v2
     with:
       promotion: ${{ github.event.inputs.promotion }}
       charm-path: ${{ github.event.inputs.charm }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
           - backend
           - chaoscenter
           - infrastructure
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit
     with:
       charm-path: ${{ matrix.charm-path }}

--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -11,25 +11,25 @@ on:
 jobs:
   quality-gates-auth:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit
     with:
       charm-path: auth
   quality-gates-chaoscenter:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit
     with:
       charm-path: chaoscenter
   quality-gates-backend:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit
     with:
       charm-path: backend
   quality-gates-infrastructure:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit
     with:
       charm-path: infrastructure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
   release-auth:
     needs: charms-changed
     if: needs.charms-changed.outputs.auth_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       default-track: dev
@@ -85,7 +85,7 @@ jobs:
   release-chaoscenter:
     needs: charms-changed
     if: needs.charms-changed.outputs.chaoscenter_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       default-track: dev
@@ -94,7 +94,7 @@ jobs:
   release-backend:
     needs: charms-changed
     if: needs.charms-changed.outputs.backend_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       default-track: dev
@@ -103,7 +103,7 @@ jobs:
   release-infrastructure:
     needs: charms-changed
     if: needs.charms-changed.outputs.infrastructure_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       default-track: dev

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
     tiobe-scan:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
         with:
             tiobe-project-name: litmus-operators
             coverage-folder: coverage

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,28 +9,28 @@ on:
 jobs:
   update-lib-auth:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
     with:
       charm-path: auth
       git-branch: chore/auto-libs/auth
   update-lib-chaoscenter:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
     with:
       charm-path: chaoscenter
       git-branch: chore/auto-libs/chaoscenter
   update-lib-backend:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
     with:
       charm-path: backend
       git-branch: chore/auto-libs/backend
   update-lib-infrastructure:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
     with:
       charm-path: infrastructure


### PR DESCRIPTION
Update all `canonical/observability` reusable workflow references to use the `v2` tag.