### PR TITLE
feat(terraform): Support for Juju provider v2

### DIFF
--- a/auth/terraform/terraform.tf
+++ b/auth/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0" # Using 0.14.0 to match MongoDB's strict version requirement
+      version = ">= 1.0"
     }
   }
 }

--- a/backend/terraform/terraform.tf
+++ b/backend/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0" # Using 0.14.0 to match MongoDB's strict version requirement
+      version = ">= 1.0"
     }
   }
 }

--- a/chaoscenter/terraform/terraform.tf
+++ b/chaoscenter/terraform/terraform.tf
@@ -2,11 +2,10 @@
 # See LICENSE file for licensing details.
 
 terraform {
-  required_version = ">= 1.5"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = ">= 1.0"
     }
   }
 }

--- a/infrastructure/terraform/terraform.tf
+++ b/infrastructure/terraform/terraform.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = ">= 1.5"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0" # Using 0.14.0 to match MongoDB's strict version requirement
+      version = ">= 1.0"
     }
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0" # Using 0.14.0 to match MongoDB's strict version requirement
+      version = ">= 1.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
The TF Juju provider [released 2.0.0](https://github.com/juju/terraform-provider-juju/releases/tag/v2.0.0) on May 26th, 2026 and we need to support this because of the Juju v4 support. This major version is said to not have any breaking changes so we are safe to bump our Juju provider version support:
- `"~> 1.0"` -> `">= 1.0"`

## Solution
- update the Juju provider version to `">= 1.0"`
- rename versions.tf to terraform.tf

## Testing Instructions
See the passing CI in this PR:
- https://github.com/canonical/observability-stack/pull/366

## Upgrade Notes
Users of the product module (deployment modules) can pin the provider version if they want to. We will catch breaking changes in CI when Juju provider releases v3 and we can decide if we want to pin COS 3.0 to `<3` at that point in time.